### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,8 @@
 name: CI
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [main]


### PR DESCRIPTION
Potential fix for [https://github.com/lcmen/go-pty/security/code-scanning/1](https://github.com/lcmen/go-pty/security/code-scanning/1)

In general, the fix is to explicitly restrict the `GITHUB_TOKEN` permissions for this workflow to the minimum needed. This workflow only checks out code and runs tests/builds; it does not appear to need any write access. Therefore, defining `permissions: contents: read` at the workflow root is an appropriate least-privilege setting and will apply to all jobs that don’t override it.

The best fix without changing functionality is to add a top-level `permissions` block just under the existing `name: CI` line in `.github/workflows/ci.yml`. This will (1) document the workflow’s needs, (2) ensure that even if org/repo defaults are read-write, this workflow uses read-only, and (3) avoid having to repeat the same block in each job. No additional methods, imports, or definitions are required, since this is purely a YAML configuration change within the workflow file.

Concretely: edit `.github/workflows/ci.yml` to insert:

```yaml
permissions:
  contents: read
```

between lines 1 and 3 (after the `name: CI` line and its following blank line), preserving the rest of the file unchanged.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
